### PR TITLE
display camera image corresponding to prediction token pair

### DIFF
--- a/forecast/pred_cam_view.ipynb
+++ b/forecast/pred_cam_view.ipynb
@@ -1,0 +1,156 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python_defaultSpec_1600327160252",
+   "display_name": "Python 3.7.3 64-bit ('base': conda)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import argparse\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from PIL import Image\n",
+    "import numpy as np\n",
+    "\n",
+    "from nuscenes import NuScenes\n",
+    "from nuscenes.eval.prediction.config import load_prediction_config\n",
+    "from nuscenes.eval.prediction.splits import get_prediction_challenge_split\n",
+    "from nuscenes.prediction import PredictHelper\n",
+    "from nuscenes.prediction.input_representation.static_layers import StaticLayerRasterizer\n",
+    "from nuscenes.prediction.input_representation.agents import AgentBoxesWithFadedHistory\n",
+    "from nuscenes.prediction.input_representation.interface import InputRepresentation\n",
+    "from nuscenes.prediction.input_representation.combinators import Rasterizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_im_and_box(nusc, token, cam_name=\"CAM_FRONT\"):\n",
+    "    \"\"\"\n",
+    "    Plots the camera view with bounding box around the agent to be predicted\n",
+    "    :param ax: matplotlib axes object\n",
+    "    :param nusc: NuScenes object\n",
+    "    :param token: Prediction token consisting of instance_sample token pair\n",
+    "    :param cam_name: Name of camera to use\n",
+    "    :return: (image, box, camera_instrinsic)\n",
+    "    \"\"\"\n",
+    "    instance_token, sample_token = token.split('_')\n",
+    "    # get tokens\n",
+    "    sample = nusc.get('sample', sample_token)\n",
+    "    sample_cam_token = nusc.get('sample_data', sample['data'][cam_name])['token']\n",
+    "    annotations_in_sample = [nusc.get('sample_annotation', annotation) for annotation in sample['anns']]\n",
+    "    annotation_instance, *_ = (ann for ann in annotations_in_sample if ann['instance_token'] == instance_token)\n",
+    "    # plot\n",
+    "    data_path, boxes, camera_intrinsic = nusc.get_sample_data(sample_cam_token, selected_anntokens=[annotation_instance['token']])\n",
+    "    im = Image.open(data_path)\n",
+    "    if len(boxes) > 0:\n",
+    "        return im, boxes[0], camera_intrinsic\n",
+    "    else:\n",
+    "        return im, None, camera_intrinsic\n",
+    "\n",
+    "def plot_cam_view(ax, nusc, token, cam_name='CAM_FRONT'):\n",
+    "    \"\"\"\n",
+    "    Plots the camera view with bounding box around the agent to be predicted\n",
+    "    :param ax: matplotlib axes object\n",
+    "    :param nusc: NuScenes object\n",
+    "    :param token: Prediction token consisting of instance_sample token pair\n",
+    "    :param cam_name: Name of camera to use\n",
+    "    \"\"\"\n",
+    "    im, box, camera_intrinsic = get_im_and_box(nusc, token, cam_name)\n",
+    "    ax.imshow(im)\n",
+    "    ax.set_title(cam_name)\n",
+    "    ax.axis('off')\n",
+    "    ax.set_aspect('equal')\n",
+    "    if box is not None:\n",
+    "        c = np.array(nusc.explorer.get_color(box.name)) / 255.0\n",
+    "        box.render(ax, view=camera_intrinsic, normalize=True, colors=(c, c, c))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "version = 'v1.0-mini'\n",
+    "data_root = '/Users/Gerry/Downloads/v1.0-mini'\n",
+    "split_name = 'mini_train'\n",
+    "config_name = 'predict_2020_icra.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "======\nLoading NuScenes tables for version v1.0-mini...\n23 category,\n8 attribute,\n4 visibility,\n911 instance,\n12 sensor,\n120 calibrated_sensor,\n31206 ego_pose,\n8 log,\n10 scene,\n404 sample,\n31206 sample_data,\n18538 sample_annotation,\n4 map,\nDone loading in 0.673 seconds.\n======\nReverse indexing ...\nDone reverse indexing in 0.2 seconds.\n======\n"
+    }
+   ],
+   "source": [
+    "nusc = NuScenes(version=version, dataroot=data_root)\n",
+    "helper = PredictHelper(nusc)\n",
+    "dataset = get_prediction_challenge_split(split_name, dataroot=data_root)\n",
+    "config = load_prediction_config(helper, config_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "static_layer_rasterizer = StaticLayerRasterizer(helper)\n",
+    "agent_rasterizer = AgentBoxesWithFadedHistory(helper, seconds_of_history=3)\n",
+    "mtp_input_representation = InputRepresentation(static_layer_rasterizer, agent_rasterizer, Rasterizer())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for token in dataset[40:60:2]:\n",
+    "    fig, axes = plt.subplots(1, 3, figsize=(18, 9))\n",
+    "    print(token)\n",
+    "    instance_token, sample_token = token.split('_')\n",
+    "\n",
+    "    plot_cam_view(axes[1], nusc, token)\n",
+    "    plot_cam_view(axes[2], nusc, token, cam_name='CAM_FRONT_RIGHT')\n",
+    "    axes[0].imshow(mtp_input_representation.make_input_representation(instance_token, sample_token))\n",
+    "plt.show()"
+   ]
+  }
+ ]
+}

--- a/forecast/pred_cam_view.ipynb
+++ b/forecast/pred_cam_view.ipynb
@@ -23,7 +23,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,17 +106,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "======\nLoading NuScenes tables for version v1.0-mini...\n23 category,\n8 attribute,\n4 visibility,\n911 instance,\n12 sensor,\n120 calibrated_sensor,\n31206 ego_pose,\n8 log,\n10 scene,\n404 sample,\n31206 sample_data,\n18538 sample_annotation,\n4 map,\nDone loading in 0.673 seconds.\n======\nReverse indexing ...\nDone reverse indexing in 0.2 seconds.\n======\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nusc = NuScenes(version=version, dataroot=data_root)\n",
     "helper = PredictHelper(nusc)\n",
@@ -126,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +135,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for token in dataset[40:60:2]:\n",
+    "index = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for token in dataset[index:index+1]:\n",
     "    fig, axes = plt.subplots(1, 3, figsize=(18, 9))\n",
     "    print(token)\n",
     "    instance_token, sample_token = token.split('_')\n",
@@ -149,8 +154,16 @@
     "    plot_cam_view(axes[1], nusc, token)\n",
     "    plot_cam_view(axes[2], nusc, token, cam_name='CAM_FRONT_RIGHT')\n",
     "    axes[0].imshow(mtp_input_representation.make_input_representation(instance_token, sample_token))\n",
-    "plt.show()"
+    "plt.show()\n",
+    "index += 2"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ]
 }

--- a/forecast/pred_cam_view.py
+++ b/forecast/pred_cam_view.py
@@ -1,7 +1,8 @@
 # nuScenes dev-kit.
 # Code written by Freddy Boulton, 2020.
+#   Adapted by Gerry Chen, 2020
 
-""" Script for running baseline models on a given nuscenes-split. """
+""" Script for viewing camera images from a given data sample. """
 
 import argparse
 import json
@@ -87,7 +88,7 @@ def main(version: str, data_root: str,
     mtp_input_representation = InputRepresentation(static_layer_rasterizer, agent_rasterizer, Rasterizer())
 
     # loop through training tasks
-    for token in dataset[0:20:3]:
+    for token in dataset[40:60:2]:
         fig, axes = plt.subplots(1, 3, figsize=(18, 9))
         print(token)
         instance_token, sample_token = token.split('_')

--- a/forecast/pred_cam_view.py
+++ b/forecast/pred_cam_view.py
@@ -1,0 +1,105 @@
+# nuScenes dev-kit.
+# Code written by Freddy Boulton, 2020.
+
+""" Script for running baseline models on a given nuscenes-split. """
+
+import argparse
+import json
+import os
+
+import matplotlib.pyplot as plt
+from PIL import Image
+import numpy as np
+
+from nuscenes import NuScenes
+from nuscenes.eval.prediction.config import load_prediction_config
+from nuscenes.eval.prediction.splits import get_prediction_challenge_split
+from nuscenes.prediction import PredictHelper
+from nuscenes.prediction.input_representation.static_layers import StaticLayerRasterizer
+from nuscenes.prediction.input_representation.agents import AgentBoxesWithFadedHistory
+from nuscenes.prediction.input_representation.interface import InputRepresentation
+from nuscenes.prediction.input_representation.combinators import Rasterizer
+
+def get_im_and_box(nusc, token, cam_name="CAM_FRONT"):
+    """
+    Plots the camera view with bounding box around the agent to be predicted
+    :param ax: matplotlib axes object
+    :param nusc: NuScenes object
+    :param token: Prediction token consisting of instance_sample token pair
+    :param cam_name: Name of camera to use
+    :return: (image, box, camera_instrinsic)
+    """
+    instance_token, sample_token = token.split('_')
+    # get tokens
+    sample = nusc.get('sample', sample_token)
+    sample_cam_token = nusc.get('sample_data', sample['data'][cam_name])['token']
+    annotations_in_sample = [nusc.get('sample_annotation', annotation) for annotation in sample['anns']]
+    annotation_instance, *_ = (ann for ann in annotations_in_sample if ann['instance_token'] == instance_token)
+    # plot
+    data_path, boxes, camera_intrinsic = nusc.get_sample_data(sample_cam_token, selected_anntokens=[annotation_instance['token']])
+    im = Image.open(data_path)
+    if len(boxes) > 0:
+        return im, boxes[0], camera_intrinsic
+    else:
+        return im, None, camera_intrinsic
+
+def plot_cam_view(ax, nusc, token, cam_name='CAM_FRONT'):
+    """
+    Plots the camera view with bounding box around the agent to be predicted
+    :param ax: matplotlib axes object
+    :param nusc: NuScenes object
+    :param token: Prediction token consisting of instance_sample token pair
+    :param cam_name: Name of camera to use
+    """
+    im, box, camera_intrinsic = get_im_and_box(nusc, token, cam_name)
+    ax.imshow(im)
+    ax.set_title(cam_name)
+    ax.axis('off')
+    ax.set_aspect('equal')
+    if box is not None:
+        c = np.array(nusc.explorer.get_color(box.name)) / 255.0
+        box.render(ax, view=camera_intrinsic, normalize=True, colors=(c, c, c))
+
+def main(version: str, data_root: str,
+         split_name: str, output_dir: str, config_name: str = 'predict_2020_icra.json') -> None:
+    """
+    Performs inference for all of the baseline models defined in the physics model module.
+    :param version: nuScenes data set version.
+    :param data_root: Directory where the NuScenes data is stored.
+    :param split_name: nuScenes data split name, e.g. train, val, mini_train, etc.
+    :param output_dir: Directory where predictions should be stored.
+    :param config_name: Name of config file.
+    """
+
+    print('timing point A')
+    nusc = NuScenes(version=version, dataroot=data_root)
+    print('timing point B')
+    helper = PredictHelper(nusc)
+    print('timing point C')
+    dataset = get_prediction_challenge_split(split_name, dataroot=data_root)
+    print('timing point D')
+    config = load_prediction_config(helper, config_name)
+    print('timing point E')
+
+    # rasterization
+    static_layer_rasterizer = StaticLayerRasterizer(helper)
+    agent_rasterizer = AgentBoxesWithFadedHistory(helper, seconds_of_history=3)
+    mtp_input_representation = InputRepresentation(static_layer_rasterizer, agent_rasterizer, Rasterizer())
+
+    # loop through training tasks
+    for token in dataset[0:20:3]:
+        fig, axes = plt.subplots(1, 3, figsize=(18, 9))
+        print(token)
+        instance_token, sample_token = token.split('_')
+
+        plot_cam_view(axes[1], nusc, token)
+        plot_cam_view(axes[2], nusc, token, cam_name='CAM_FRONT_RIGHT')
+        axes[0].imshow(mtp_input_representation.make_input_representation(instance_token, sample_token))
+    plt.show()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Display data from a prediction task')
+    parser.add_argument('--config_name', help='Config file to use.', default='predict_2020_icra.json')
+
+    args = parser.parse_args()
+    main('v1.0-mini', '/Users/Gerry/Downloads/v1.0-mini', 'mini_train', 'out/', args.config_name)


### PR DESCRIPTION
Usage:

```python
from pred_cam_view import get_im_and_box, plot_cam_view
from nuscenes.eval.prediction.splits import get_prediction_challenge_split

dataset = get_prediction_challenge_split('mini_train', dataroot=data_root)
for token in dataset[0:20:3]:
    fig, axes = plt.subplots(1, 2, figsize=(18, 9))
    plot_cam_view(axes[0], nusc, token)
    plot_cam_view(axes[1], nusc, token, cam_name='CAM_FRONT_RIGHT')
plt.show()
```